### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.email/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.email/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.engagements.email.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.email/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.engagements.email.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.engagements.email)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.engagements.email.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.engagements.email)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector revamp audit.

### README (top-level)

- Fix the encoding bug in the GitHub Issues badge link: `module%hubspot.crm.engagements.email` -> `module%2Fhubspot.crm.engagements.email`.

The other systemic README fixes from the audit do not apply to this repo:

- `Hubspot` mis-casing: the only occurrences are image alt-text positions (e.g. `![Hubspot Developer Portal](...)`), which are excluded from the brand-name rewrite per the audit spec.
- `ave` typo: not present in this repo (the OAuth section already reads `you have obtained`).
- Title duplicated `Ballerina`/`Connector`: not present; the title already matches the canonical `# Ballerina HubSpot CRM Engagements Email connector` form.

## Examples

N/A - documentation-only change to `README.md`.

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog - N/A (docs-only)
- [ ] Added tests - N/A (docs-only)
- [ ] Updated the spec - N/A (docs-only)
- [x] Checked native-image compatibility - N/A (no code change)

Refs ballerina-platform/ballerina-library#8823